### PR TITLE
feat!: ship hops-default StorageClass as cluster default

### DIFF
--- a/apis/autoeksclusters/definition.yaml
+++ b/apis/autoeksclusters/definition.yaml
@@ -177,6 +177,27 @@ spec:
                   description: Enable KMS encryption for Kubernetes secrets.
                   default: true
 
+                # Storage
+                storage:
+                  type: object
+                  description: |
+                    Cluster storage defaults. EKS Auto Mode ships the EBS CSI driver
+                    (ebs.csi.eks.amazonaws.com) but does not create a default StorageClass.
+                    By default this composition creates `hops-default` (gp3, encrypted,
+                    WaitForFirstConsumer, expandable) and marks it the cluster-default SC.
+                  properties:
+                    defaultClass:
+                      type: object
+                      description: Default StorageClass settings.
+                      properties:
+                        enabled:
+                          type: boolean
+                          description: |
+                            Create the `hops-default` StorageClass and mark it as the
+                            cluster-default. Set to false to opt out (e.g. when a downstream
+                            stack provides its own default).
+                          default: true
+
                 # KMS Key configuration
                 kms:
                   type: object

--- a/functions/render/000-state-init.yaml.gotmpl
+++ b/functions/render/000-state-init.yaml.gotmpl
@@ -31,6 +31,12 @@
 {{ $disruptionConfig := $nodePoolConfig.disruption | default (dict) }}
 {{ $sgRules := $spec.securityGroupRules | default (dict) }}
 {{ $oidcConfig := $spec.oidc | default (dict) }}
+{{ $storageConfig := $spec.storage | default (dict) }}
+{{ $defaultClassConfig := $storageConfig.defaultClass | default (dict) }}
+{{ $defaultClassEnabled := true }}
+{{ if hasKey $defaultClassConfig "enabled" }}
+  {{ $defaultClassEnabled = $defaultClassConfig.enabled }}
+{{ end }}
 
 {{ $subnetSelector := $spec.subnetSelector | default (dict) }}
 {{ $iam := $spec.iam | default (dict) }}
@@ -85,6 +91,11 @@
   "oidc" (dict
     "enabled" ($oidcConfig.enabled | default false)
     "externalName" ($oidcConfig.externalName | default "")
+  )
+  "storage" (dict
+    "defaultClass" (dict
+      "enabled" $defaultClassEnabled
+    )
   )
   "nodeConfig" (dict
     "enabled" ($nodeConfig.enabled | default true)

--- a/functions/render/005-state-automode.yaml.gotmpl
+++ b/functions/render/005-state-automode.yaml.gotmpl
@@ -32,6 +32,8 @@
 {{ $renderSecurityGroupRules := and $eff.securityGroupRules.enabled (ne $obs.cluster.securityGroupId "") }}
 # NodeConfig requires: enabled, clusterAuth ready, security group available, and observed subnets available
 {{ $renderNodeConfig := and $eff.nodeConfig.enabled $obs.clusterAuth.ready (ne $obs.cluster.securityGroupId "") $obs.cluster.subnetIds }}
+# Default StorageClass requires: enabled, clusterAuth ready (cluster's k8s ProviderConfig is usable)
+{{ $renderDefaultStorageClass := and $eff.storage.defaultClass.enabled $obs.clusterAuth.ready }}
 
 # ==============================================================================
 # Build $state.automode
@@ -79,6 +81,8 @@
   "nodeConfig" $eff.nodeConfig
   "nodeClassTags" $nodeClassTags
 
+  "storage" $eff.storage
+
   "providerConfig" $eff.providerConfigRef
   "kubernetesProviderConfig" $eff.kubernetesProviderConfigRef
 
@@ -95,6 +99,7 @@
     "oidc" $renderOidc
     "securityGroupRules" $renderSecurityGroupRules
     "nodeConfig" $renderNodeConfig
+    "defaultStorageClass" $renderDefaultStorageClass
   )
 }}
 

--- a/functions/render/95-default-storage-class.yaml.gotmpl
+++ b/functions/render/95-default-storage-class.yaml.gotmpl
@@ -1,0 +1,40 @@
+# code: language=yaml
+# Default cluster StorageClass: hops-default
+#
+# EKS Auto Mode ships the EBS CSI driver (ebs.csi.eks.amazonaws.com) but does not
+# create or default a StorageClass. Without this, PVCs that omit storageClassName
+# stay Pending forever and downstream stacks improvise by piggybacking on incidental
+# SCs from other stacks. See specs/aws-eks-auto-mode-default-storage-class.
+
+{{ $am := $state.automode }}
+
+{{ if $am.render.defaultStorageClass }}
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  name: {{ $am.cluster.name }}-default-storage-class
+  labels: {{ $am.labels | toJson }}
+  annotations:
+    {{ setResourceNameAnnotation "default-storage-class" }}
+spec:
+  managementPolicies: {{ $am.managementPolicies | toJson }}
+  forProvider:
+    manifest:
+      apiVersion: storage.k8s.io/v1
+      kind: StorageClass
+      metadata:
+        name: hops-default
+        annotations:
+          storageclass.kubernetes.io/is-default-class: "true"
+      provisioner: ebs.csi.eks.amazonaws.com
+      parameters:
+        type: gp3
+        encrypted: "true"
+      volumeBindingMode: WaitForFirstConsumer
+      reclaimPolicy: Delete
+      allowVolumeExpansion: true
+  providerConfigRef:
+    name: {{ $am.cluster.name }}
+    kind: ProviderConfig
+{{ end }}

--- a/tests/test-render/main.k
+++ b/tests/test-render/main.k
@@ -633,6 +633,255 @@ _items = [
         }
     }
 
+    # Test: hops-default StorageClass renders by default once clusterAuth is ready.
+    # Asserts the Object MR wrapping the StorageClass exists and carries the cluster-default
+    # annotation, gp3 + encrypted parameters, and WaitForFirstConsumer binding mode.
+    metav1alpha1.CompositionTest{
+        metadata.name = "default-renders-hops-default-storage-class"
+        spec = {
+            compositionPath = "apis/autoeksclusters/composition.yaml"
+            xrdPath = "apis/autoeksclusters/definition.yaml"
+            timeoutSeconds = 120
+            validate = True
+            xr = awsv1alpha1.AutoEKSCluster{
+                metadata.name = "test-sc-default"
+                spec = {
+                    clusterName = "test-sc-default"
+                    region = "us-east-1"
+                    accountId = "123456789012"
+                    version = "1.31"
+                    subnetIds = ["subnet-aaa"]
+                }
+            }
+            observedResources = [
+                {
+                    apiVersion = "iam.aws.m.upbound.io/v1beta1"
+                    kind = "Role"
+                    metadata = {
+                        name = "test-sc-default-controlplane"
+                        annotations = {
+                            "crossplane.io/composition-resource-name" = "iam-role-controlplane"
+                            "gotemplating.fn.crossplane.io/composition-resource-name" = "iam-role-controlplane"
+                        }
+                    }
+                    status = {
+                        conditions = [{type = "Ready", status = "True", reason = "Available"}]
+                        atProvider = {arn = "arn:aws:iam::123456789012:role/test-sc-default-controlplane", name = "test-sc-default-controlplane"}
+                    }
+                }
+                {
+                    apiVersion = "iam.aws.m.upbound.io/v1beta1"
+                    kind = "Role"
+                    metadata = {
+                        name = "test-sc-default-node"
+                        annotations = {
+                            "crossplane.io/composition-resource-name" = "iam-role-node"
+                            "gotemplating.fn.crossplane.io/composition-resource-name" = "iam-role-node"
+                        }
+                    }
+                    status = {
+                        conditions = [{type = "Ready", status = "True", reason = "Available"}]
+                        atProvider = {arn = "arn:aws:iam::123456789012:role/test-sc-default-node", name = "test-sc-default-node"}
+                    }
+                }
+                {
+                    apiVersion = "kms.aws.m.upbound.io/v1beta1"
+                    kind = "Key"
+                    metadata = {
+                        name = "test-sc-default-secrets"
+                        annotations = {
+                            "crossplane.io/composition-resource-name" = "kms-key"
+                            "gotemplating.fn.crossplane.io/composition-resource-name" = "kms-key"
+                        }
+                    }
+                    status = {
+                        conditions = [{type = "Ready", status = "True", reason = "Available"}]
+                        atProvider = {arn = "arn:aws:kms:us-east-1:123456789012:key/12345678", keyId = "12345678"}
+                    }
+                }
+                {
+                    apiVersion = "eks.aws.m.upbound.io/v1beta1"
+                    kind = "Cluster"
+                    metadata = {
+                        name = "test-sc-default"
+                        annotations = {
+                            "crossplane.io/composition-resource-name" = "cluster"
+                            "gotemplating.fn.crossplane.io/composition-resource-name" = "cluster"
+                        }
+                    }
+                    status = {
+                        conditions = [{type = "Ready", status = "True", reason = "Available"}]
+                        atProvider = {
+                            arn = "arn:aws:eks:us-east-1:123456789012:cluster/test-sc-default"
+                            endpoint = "https://ABCDEF.gr7.us-east-1.eks.amazonaws.com"
+                            id = "test-sc-default"
+                            identity = [{oidc = [{issuer = "https://oidc.eks.us-east-1.amazonaws.com/id/ABCDEF"}]}]
+                            status = "ACTIVE"
+                            vpcConfig = {
+                                clusterSecurityGroupId = "sg-012345"
+                                subnetIds = ["subnet-aaa"]
+                            }
+                        }
+                    }
+                }
+                {
+                    apiVersion = "eks.aws.m.upbound.io/v1beta1"
+                    kind = "ClusterAuth"
+                    metadata = {
+                        name = "test-sc-default"
+                        annotations = {
+                            "crossplane.io/composition-resource-name" = "cluster-auth"
+                            "gotemplating.fn.crossplane.io/composition-resource-name" = "cluster-auth"
+                        }
+                    }
+                    status = {
+                        conditions = [{type = "Ready", status = "True", reason = "Available"}]
+                        atProvider = {clusterName = "test-sc-default", region = "us-east-1"}
+                    }
+                }
+            ]
+            assertResources = [
+                {
+                    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+                    kind = "Object"
+                    metadata.name = "test-sc-default-default-storage-class"
+                    spec.forProvider.manifest = {
+                        apiVersion = "storage.k8s.io/v1"
+                        kind = "StorageClass"
+                        metadata = {
+                            name = "hops-default"
+                            annotations = {"storageclass.kubernetes.io/is-default-class" = "true"}
+                        }
+                        provisioner = "ebs.csi.eks.amazonaws.com"
+                        parameters = {type = "gp3", encrypted = "true"}
+                        volumeBindingMode = "WaitForFirstConsumer"
+                        reclaimPolicy = "Delete"
+                        allowVolumeExpansion = True
+                    }
+                }
+            ]
+        }
+    }
+
+    # Test: storage.defaultClass.enabled = False skips the SC render but the rest of
+    # the cluster-auth-gated pipeline (k8s ProviderConfig Object) still renders.
+    metav1alpha1.CompositionTest{
+        metadata.name = "storage-default-disabled-skips-sc"
+        spec = {
+            compositionPath = "apis/autoeksclusters/composition.yaml"
+            xrdPath = "apis/autoeksclusters/definition.yaml"
+            timeoutSeconds = 120
+            validate = True
+            xr = awsv1alpha1.AutoEKSCluster{
+                metadata.name = "test-sc-disabled"
+                spec = {
+                    clusterName = "test-sc-disabled"
+                    region = "us-east-1"
+                    accountId = "123456789012"
+                    version = "1.31"
+                    subnetIds = ["subnet-aaa"]
+                    storage = {defaultClass = {enabled = False}}
+                }
+            }
+            observedResources = [
+                {
+                    apiVersion = "iam.aws.m.upbound.io/v1beta1"
+                    kind = "Role"
+                    metadata = {
+                        name = "test-sc-disabled-controlplane"
+                        annotations = {
+                            "crossplane.io/composition-resource-name" = "iam-role-controlplane"
+                            "gotemplating.fn.crossplane.io/composition-resource-name" = "iam-role-controlplane"
+                        }
+                    }
+                    status = {
+                        conditions = [{type = "Ready", status = "True", reason = "Available"}]
+                        atProvider = {arn = "arn:aws:iam::123456789012:role/test-sc-disabled-controlplane", name = "test-sc-disabled-controlplane"}
+                    }
+                }
+                {
+                    apiVersion = "iam.aws.m.upbound.io/v1beta1"
+                    kind = "Role"
+                    metadata = {
+                        name = "test-sc-disabled-node"
+                        annotations = {
+                            "crossplane.io/composition-resource-name" = "iam-role-node"
+                            "gotemplating.fn.crossplane.io/composition-resource-name" = "iam-role-node"
+                        }
+                    }
+                    status = {
+                        conditions = [{type = "Ready", status = "True", reason = "Available"}]
+                        atProvider = {arn = "arn:aws:iam::123456789012:role/test-sc-disabled-node", name = "test-sc-disabled-node"}
+                    }
+                }
+                {
+                    apiVersion = "kms.aws.m.upbound.io/v1beta1"
+                    kind = "Key"
+                    metadata = {
+                        name = "test-sc-disabled-secrets"
+                        annotations = {
+                            "crossplane.io/composition-resource-name" = "kms-key"
+                            "gotemplating.fn.crossplane.io/composition-resource-name" = "kms-key"
+                        }
+                    }
+                    status = {
+                        conditions = [{type = "Ready", status = "True", reason = "Available"}]
+                        atProvider = {arn = "arn:aws:kms:us-east-1:123456789012:key/12345678", keyId = "12345678"}
+                    }
+                }
+                {
+                    apiVersion = "eks.aws.m.upbound.io/v1beta1"
+                    kind = "Cluster"
+                    metadata = {
+                        name = "test-sc-disabled"
+                        annotations = {
+                            "crossplane.io/composition-resource-name" = "cluster"
+                            "gotemplating.fn.crossplane.io/composition-resource-name" = "cluster"
+                        }
+                    }
+                    status = {
+                        conditions = [{type = "Ready", status = "True", reason = "Available"}]
+                        atProvider = {
+                            arn = "arn:aws:eks:us-east-1:123456789012:cluster/test-sc-disabled"
+                            endpoint = "https://ABCDEF.gr7.us-east-1.eks.amazonaws.com"
+                            id = "test-sc-disabled"
+                            identity = [{oidc = [{issuer = "https://oidc.eks.us-east-1.amazonaws.com/id/ABCDEF"}]}]
+                            status = "ACTIVE"
+                            vpcConfig = {
+                                clusterSecurityGroupId = "sg-012345"
+                                subnetIds = ["subnet-aaa"]
+                            }
+                        }
+                    }
+                }
+                {
+                    apiVersion = "eks.aws.m.upbound.io/v1beta1"
+                    kind = "ClusterAuth"
+                    metadata = {
+                        name = "test-sc-disabled"
+                        annotations = {
+                            "crossplane.io/composition-resource-name" = "cluster-auth"
+                            "gotemplating.fn.crossplane.io/composition-resource-name" = "cluster-auth"
+                        }
+                    }
+                    status = {
+                        conditions = [{type = "Ready", status = "True", reason = "Available"}]
+                        atProvider = {clusterName = "test-sc-disabled", region = "us-east-1"}
+                    }
+                }
+            ]
+            assertResources = [
+                # Sibling Object MRs gated on clusterAuth.ready still render — proves
+                # the template pipeline ran past the SC step without error.
+                {
+                    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+                    kind = "Object"
+                    metadata.name = "test-sc-disabled-k8s-provider-config"
+                }
+            ]
+        }
+    }
+
 ]
 
 items = _items


### PR DESCRIPTION
## Summary

- Adds a `hops-default` StorageClass (gp3, encrypted, WaitForFirstConsumer, expandable) to every AutoEKSCluster, annotated as the cluster-default. EKS Auto Mode ships the EBS CSI driver but no default SC, so PVCs without `storageClassName` previously stayed Pending forever and downstream stacks improvised by piggybacking on incidental SCs (e.g. `redis.storageClassName: loki`).
- New `spec.storage.defaultClass.enabled` (bool, default `true`) for opt-out.
- Render gated on `clusterAuth.ready` (same precondition as `nodeConfig`).
- Uses the `hasKey` guard pattern for the new boolean — sprig's `default true` would flip explicit `false` back to `true`.

## Breaking change

AutoEKSCluster now installs a StorageClass named `hops-default` annotated as the cluster-default. Clusters that already mark a different SC as the cluster-default will end up with two default SCs and Kubernetes' selection between them is undefined. To keep an existing default SC, set `spec.storage.defaultClass.enabled: false`.

## Test plan

- [x] `make render:all` clean across all examples (SC renders at step 3+ once ClusterAuth is ready)
- [x] `make validate:all` clean
- [x] `make test` — 12/12 KCL tests pass (10 existing + 2 new: `default-renders-hops-default-storage-class`, `storage-default-disabled-skips-sc`)
- [x] Verified live on `pat-local` via `hops config install --path .` — `kubectl get sc` shows `hops-default (default)` as the only SC carrying the cluster-default annotation
- [x] No-class PVC bound to a fresh `hops-default` volume once a consuming pod scheduled
- [x] No regression: existing `loki` / `kubescape` / `prometheus` / `tempo` / `psql` PVCs remain Bound

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added storage configuration for EKS Auto Mode clusters, including a configurable default StorageClass named `hops-default`
  * Default StorageClass uses gp3 volumes with encryption enabled and supports volume expansion

* **Tests**
  * Added comprehensive test coverage for StorageClass rendering scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hops-ops/aws-auto-eks-cluster/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->